### PR TITLE
Fix to KeyError in ICAT facade.py

### DIFF
--- a/src/server/apps/catalog/icat/facade.py
+++ b/src/server/apps/catalog/icat/facade.py
@@ -251,5 +251,12 @@ class Catalog(object):
             logger.error("ICAT did not return the expected result. Are the instrument and experiment id valids?")
             return None
 
-        json_data_subset = {"data" : [ [entry['@id'],entry['title']] for entry in json_data] }
+        data_list = list()
+        for entry in json_data:
+            title = None
+            if 'title' in entry:
+                title = entry['title']
+            data_list.append([entry['@id'],title])
+
+        json_data_subset = {"data" : data_list }
         return json_data_subset;


### PR DESCRIPTION
Added fix when title does not exist for run information. Just initializing the title entry.
Below reproduces error (specifically for run id `77108` in this experiment). Got KeyError using following:

```
from catalog.icat.facade import Catalog
client = Catalog()
output = client.get_run_number_and_title('NOM', 'IPTS-17210')
```